### PR TITLE
Create Ingredients and Instructions

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="development" uuid="f68d398e-cdbc-458c-ac19-b1e65a18f577">
+      <driver-ref>sqlite.xerial</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.sqlite.JDBC</jdbc-driver>
+      <jdbc-url>jdbc:sqlite:$PROJECT_DIR$/db/development.sqlite3</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/db/recipe_parser.rb
+++ b/db/recipe_parser.rb
@@ -13,8 +13,8 @@ def extract_recipes(raw_recipes, breaks)
     white_breaks = recipe_temp.each_index.select { |i| recipe_temp[i] == ''}
     recipe = { "name" => recipe_temp[0], "cuisine" => recipe_temp[1], "servings" => recipe_temp[2],
                "vegetarian" => recipe_temp[3], "vegan" => recipe_temp[4],
-               "instructions" => recipe_temp[white_breaks[0]..white_breaks[1]].delete_if { |i| i == '' },
-               "ingredients" => recipe_temp[white_breaks[1]..recipe_temp.length].delete_if { |i| i == '' } }
+               "ingredients" => recipe_temp[white_breaks[0]..white_breaks[1]].delete_if { |i| i == '' },
+               "instructions" => recipe_temp[white_breaks[1]..recipe_temp.length].delete_if { |i| i == '' } }
     recipe_start = recipe_end
     recipe_list << recipe
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,59 +14,64 @@ require_relative 'recipe_parser'
 #
 #
 FoodItem.create(
-  [{item: "tomato", food_type: "solid", category: "vegetable", measure: "whole"},
-   {item: "onion", food_type: "solid", category: "vegetable", measure: "whole"},
-   {item: "garlic", food_type: "solid", category: "vegetable", measure: "clove"},
-   {item: "leek", food_type: "solid", category: "vegetable", measure: "whole"},
-   {item: "celery", food_type: "solid", category: "vegetable", measure: "stalk"},
-   {item: "leek", food_type: "solid", category: "vegetable", measure: "whole"},
-   {item: "Lettuce", food_type: "solid", category: "vegetable", measure: "head"},
-   {item: "spinich", food_type: "solid", category: "vegetable", measure: "piece"},
-   {item: "carrot", food_type: "solid", category: "vegetable", measure: "whole"},
-   {item: "green bean", food_type: "solid", category: "vegetable", measure: "whole"},
-   {item: "pea", food_type: "solid", category: "vegetable", measure: "pod"},
-   {item: "banana", food_type: "solid", category: "fruit", measure: "whole"},
-   {item: "strawberry", food_type: "solid", category: "fruit", measure: "whole"},
-   {item: "blueberry", food_type: "solid", category: "fruit", measure: "whole"},
-   {item: "raspberry", food_type: "solid", category: "fruit", measure: "whole"},
-   {item: "cantalope", food_type: "solid", category: "fruit", measure: "whole"},
-   {item: "apple", food_type: "solid", category: "fruit", measure: "whole"},
-   {item: "banana", food_type: "solid", category: "fruit", measure: "whole"},
-   {item: "flour", food_type: "solid", category: "cereal", measure: "weight"},
-   {item: "lentil", food_type: "solid", category: "dry-legume", measure: "volume"},
-   {item: "bean", food_type: "solid", category: "dry-legume", measure: "volume"},
-   {item: "chicken thighs", food_type: "solid", category: "meat", measure: "piece"},
-   {item: "chicken breast", food_type: "solid", category: "meat", measure: "piece"},
-   {item: "chicken wings", food_type: "solid", category: "meat", measure: "piece"},
-   {item: "chicken legs", food_type: "solid", category: "meat", measure: "piece"},
-   {item: "chicken whole", food_type: "solid", category: "meat", measure: "piece"},
-   {item: "chicken ground", food_type: "solid", category: "meat", measure: "weight"},
-   {item: "beef ground", food_type: "solid", category: "meat", measure: "weight"},
-   {item: "veal ground", food_type: "solid", category: "meat", measure: "weight"},
-   {item: "turkey ground", food_type: "solid", category: "meat", measure: "weight"},
+  [{item: 'tomato', food_type: 'solid', category: 'vegetable', measure: 'whole'},
+   {item: 'onion', food_type: 'solid', category: 'vegetable', measure: 'whole'},
+   {item: 'garlic', food_type: 'solid', category: 'vegetable', measure: 'clove'},
+   {item: 'leek', food_type: 'solid', category: 'vegetable', measure: 'whole'},
+   {item: 'celery', food_type: 'solid', category: 'vegetable', measure: 'stalk'},
+   {item: 'leek', food_type: 'solid', category: 'vegetable', measure: 'whole'},
+   {item: 'Lettuce', food_type: 'solid', category: 'vegetable', measure: 'head'},
+   {item: 'spinich', food_type: 'solid', category: 'vegetable', measure: 'piece'},
+   {item: 'carrot', food_type: 'solid', category: 'vegetable', measure: 'whole'},
+   {item: 'green bean', food_type: 'solid', category: 'vegetable', measure: 'whole'},
+   {item: 'pea', food_type: 'solid', category: 'vegetable', measure: 'pod'},
+   {item: 'banana', food_type: 'solid', category: 'fruit', measure: 'whole'},
+   {item: 'strawberry', food_type: 'solid', category: 'fruit', measure: 'whole'},
+   {item: 'blueberry', food_type: 'solid', category: 'fruit', measure: 'whole'},
+   {item: 'raspberry', food_type: 'solid', category: 'fruit', measure: 'whole'},
+   {item: 'cantalope', food_type: 'solid', category: 'fruit', measure: 'whole'},
+   {item: 'apple', food_type: 'solid', category: 'fruit', measure: 'whole'},
+   {item: 'banana', food_type: 'solid', category: 'fruit', measure: 'whole'},
+   {item: 'flour', food_type: 'solid', category: 'cereal', measure: 'weight'},
+   {item: 'lentil', food_type: 'solid', category: 'dry-legume', measure: 'volume'},
+   {item: 'bean', food_type: 'solid', category: 'dry-legume', measure: 'volume'},
+   {item: 'chicken thighs', food_type: 'solid', category: 'meat', measure: 'piece'},
+   {item: 'chicken breast', food_type: 'solid', category: 'meat', measure: 'piece'},
+   {item: 'chicken wings', food_type: 'solid', category: 'meat', measure: 'piece'},
+   {item: 'chicken legs', food_type: 'solid', category: 'meat', measure: 'piece'},
+   {item: 'chicken whole', food_type: 'solid', category: 'meat', measure: 'piece'},
+   {item: 'chicken ground', food_type: 'solid', category: 'meat', measure: 'weight'},
+   {item: 'beef ground', food_type: 'solid', category: 'meat', measure: 'weight'},
+   {item: 'veal ground', food_type: 'solid', category: 'meat', measure: 'weight'},
+   {item: 'turkey ground', food_type: 'solid', category: 'meat', measure: 'weight'},
   ]
 )
 
 all_recipes = seed_recipes
 
 all_recipes.each do |recipe|
-  Recipe.create( [{ name: recipe["name"], cuisine: recipe["cuisine"], vegetarian: recipe["vegetarian"], vegan: recipe["vegan"]}] )
-  # recipe["instructions"].each do |instruction|
-  #   #Instruction.create( [{ description: instruction }] )
-  # end
-  # recipe["ingredients"].each do |ingredient|
-  #   Ingredient.create( [{ description: ingredient }] )
-  # end
-
+  @recipe_record = Recipe.create({ name: recipe['name'], cuisine: recipe['cuisine'], vegetarian: recipe['vegetarian'],
+                                           vegan: recipe['vegan']})
+  order = 0
+  recipe['instructions'].each do |instruction|
+    Instruction.create({ description: instruction, order: order += 1, recipe_id: @recipe_record.id })
+  end
+  order = 0
+  recipe['ingredients'].each do |ingredient|
+    @food_item = FoodItem.find_by(item: ingredient)
+    @ingredient_record = Ingredient.create({ quantity: ingredient, order: order += 1, recipe_id: @recipe_record.id, 
+                                             food_item_id: 1 })
+  end
 end
 
-# create_table "recipes", force: :cascade do |t|
-#   t.string "name"
-#   t.string "cuisine"
+
+# create_table "food_items", force: :cascade do |t|
+#   t.string "item"
+#   t.string "food_type"
+#   t.string "category"
+#   t.string "measure"
 #   t.datetime "created_at", precision: 6, null: false
 #   t.datetime "updated_at", precision: 6, null: false
-#   t.integer "vegetarian", limit: 1
-#   t.integer "vegan", limit: 1
 # end
 #
 # create_table "ingredients", force: :cascade do |t|
@@ -74,10 +79,8 @@ end
 #   t.integer "order", limit: 1
 #   t.datetime "created_at", precision: 6, null: false
 #   t.datetime "updated_at", precision: 6, null: false
-#   t.integer "recipes_id"
-#   t.integer "food_items_id"
-#   t.index ["food_items_id"], name: "index_ingredients_on_food_items_id"
-#   t.index ["recipes_id"], name: "index_ingredients_on_recipes_id"
+#   t.integer "recipe_id", null: false
+#   t.integer "food_item_id", null: false
 # end
 #
 # create_table "instructions", force: :cascade do |t|
@@ -85,8 +88,7 @@ end
 #   t.integer "order", limit: 1
 #   t.datetime "created_at", precision: 6, null: false
 #   t.datetime "updated_at", precision: 6, null: false
-#   t.integer "recipes_id"
-#   t.index ["recipes_id"], name: "index_instructions_on_recipes_id"
+#   t.integer "recipe_id", null: false
 # end
 #
 # create_table "recipes", force: :cascade do |t|
@@ -96,4 +98,9 @@ end
 #   t.datetime "updated_at", precision: 6, null: false
 #   t.integer "vegetarian", limit: 1
 #   t.integer "vegan", limit: 1
+# end
+#
+# add_foreign_key "ingredients", "food_items"
+# add_foreign_key "ingredients", "recipes"
+# add_foreign_key "instructions", "recipes"
 # end


### PR DESCRIPTION
In db seed, ingredients and instructions are now added to the database. Further attention is needed for the ingredients in the future, as we will likely need to apply regex to parse apart the ingredients statements during import. Here we have bypassed the issue and simply applied a food_item_id value of 1 in order to bypass part of the complexity.